### PR TITLE
Remove stop condition in export loop

### DIFF
--- a/CertStealer/Program.cs
+++ b/CertStealer/Program.cs
@@ -207,17 +207,17 @@ public class Program
                     Console.WriteLine("Error message: ");
                     Console.WriteLine(ex.Message);
 
-                    return false;
+                    //return false; --> We should continue to search for other stores
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine("Failed to import           {0}, {1} due to unknown error.",
+                    Console.WriteLine("Failed to export           {0}, {1} due to unknown error.",
                         store.Name, store.Location);
 
                     Console.WriteLine("Error message: ");
                     Console.WriteLine(ex.Message);
 
-                    return false;
+                    //return false; --> We should continue to search for other stores
                 }
             }
 


### PR DESCRIPTION
I was trying your tool in my machine. Thank you so much for this amazing tool. I realized that whenever there is an error in one of the stores (according to your code), the loop stops, and it couldn't find the existing certificate (It happened in my machine interestingly). Therefore, in my opinion we should'nt break the loop.